### PR TITLE
Remove @InternalCoroutinesApi annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ Currently the main blockers for a 1.0 are:
 
 - ES 7.5.x should include my pull request to enable suspendCancellableCoRoutine
 - We recently added reflection based code generation that scans the sdk and adds some useful extension functions. More feature work here is coming.
-- We depend on a few things related to flow and co-routines that still require annotations like `@InternalCoroutinesApi`. Ideally we get rid of needing that anywhere before 1.0.
 - Currently asynchronous is optional and I want to make this the default way of using the library as this can be so nice with co-routines and should be the default in a modern web server. 
 
 If you want to contribute, please file tickets, create PRs, etc. For bigger work, please communicate before hand before committing a lot of your time. I'm just inventing this as I go. Let me know what you think.

--- a/src/main/kotlin/io/inbot/eskotlinwrapper/AsyncBulkIndexingSession.kt
+++ b/src/main/kotlin/io/inbot/eskotlinwrapper/AsyncBulkIndexingSession.kt
@@ -3,7 +3,6 @@ package io.inbot.eskotlinwrapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.consumeEach
@@ -41,7 +40,6 @@ private val logger = KotlinLogging.logger {}
  * Note. The design for this is still a bit in flux as this still depends on `@ExperimentalCoroutinesApi` and also
  * there are some issues with using `Channel.sendBlocking` internally.
  */
-@InternalCoroutinesApi
 @Suppress("unused")
 class AsyncBulkIndexingSession<T : Any> private constructor(
     private val dao: IndexDAO<T>,
@@ -77,7 +75,6 @@ class AsyncBulkIndexingSession<T : Any> private constructor(
                 }
             }
 
-        @InternalCoroutinesApi
         @ExperimentalCoroutinesApi
         suspend fun <T : Any> asyncBulk(
             client: RestHighLevelClient,

--- a/src/main/kotlin/io/inbot/eskotlinwrapper/BulkIndexingSession.kt
+++ b/src/main/kotlin/io/inbot/eskotlinwrapper/BulkIndexingSession.kt
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
-import kotlinx.coroutines.InternalCoroutinesApi
 import mu.KotlinLogging
 import org.elasticsearch.action.DocWriteRequest
 import org.elasticsearch.action.bulk.BulkItemResponse
@@ -42,7 +41,6 @@ private val logger = KotlinLogging.logger {}
  * @param defaultRequestOptions Defaults to what you configured on the `dao`
  *
  */
-@InternalCoroutinesApi
 class BulkIndexingSession<T : Any>(
     private val client: RestHighLevelClient,
     private val dao: IndexDAO<T>,

--- a/src/main/kotlin/io/inbot/eskotlinwrapper/IndexDAO.kt
+++ b/src/main/kotlin/io/inbot/eskotlinwrapper/IndexDAO.kt
@@ -2,7 +2,6 @@ package io.inbot.eskotlinwrapper
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
 import mu.KotlinLogging
 import org.apache.commons.lang3.RandomUtils
 import org.elasticsearch.ElasticsearchStatusException
@@ -45,7 +44,6 @@ private val logger = KotlinLogging.logger {}
  * @param defaultRequestOptions passed on all API calls. Defaults to `RequestOptions.DEFAULT`. Use this to set custom headers or override on each call on the dao.
  *
  */
-@InternalCoroutinesApi
 class IndexDAO<T : Any>(
     val indexName: String,
     private val client: RestHighLevelClient,

--- a/src/main/kotlin/org/elasticsearch/client/KotlinExtensions.kt
+++ b/src/main/kotlin/org/elasticsearch/client/KotlinExtensions.kt
@@ -3,7 +3,6 @@ package org.elasticsearch.client
 import io.inbot.eskotlinwrapper.IndexDAO
 import io.inbot.eskotlinwrapper.ModelReaderAndWriter
 import io.inbot.eskotlinwrapper.OldSuspendingActionListener.Companion.suspending
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.apache.http.HttpHost
 import org.apache.http.auth.AuthScope
 import org.apache.http.auth.UsernamePasswordCredentials
@@ -90,7 +89,6 @@ fun RestHighLevelClient(
  * This abstracts the business of telling the client which index to run against and serializing/deserializing documents in it.
  *
  */
-@InternalCoroutinesApi
 fun <T : Any> RestHighLevelClient.crudDao(
     index: String,
     modelReaderAndWriter: ModelReaderAndWriter<T>,

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/AbstractElasticSearchTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/AbstractElasticSearchTest.kt
@@ -1,7 +1,6 @@
 package io.inbot.eskotlinwrapper
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.elasticsearch.client.RestHighLevelClient
 import org.elasticsearch.client.create
 import org.elasticsearch.client.crudDao
@@ -9,7 +8,6 @@ import org.elasticsearch.common.xcontent.XContentType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 
-@InternalCoroutinesApi
 open class AbstractElasticSearchTest(val indexPrefix: String = "test", val createIndex: Boolean = true, val deleteIndexAfterTest: Boolean = true) {
     lateinit var dao: IndexDAO<TestModel>
     lateinit var esClient: RestHighLevelClient

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/BulkIndexingSessionTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/BulkIndexingSessionTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.elasticsearch.action.support.WriteRequest
 import org.junit.jupiter.api.RepeatedTest
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 
 @ExperimentalCoroutinesApi
-@InternalCoroutinesApi
 class BulkIndexingSessionTest : AbstractElasticSearchTest(indexPrefix = "bulk") {
 
     @Test

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/IndexDAOTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/IndexDAOTest.kt
@@ -3,12 +3,10 @@ package io.inbot.eskotlinwrapper
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.elasticsearch.ElasticsearchStatusException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-@InternalCoroutinesApi
 class IndexDAOTest : AbstractElasticSearchTest(indexPrefix = "crud") {
     @Test
     fun `index and delete a document`() {

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/IndexManagementTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/IndexManagementTest.kt
@@ -3,7 +3,6 @@ package io.inbot.eskotlinwrapper
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type
@@ -12,7 +11,6 @@ import org.elasticsearch.client.crudDao
 import org.elasticsearch.common.xcontent.XContentType
 import org.junit.jupiter.api.Test
 
-@InternalCoroutinesApi
 class IndexManagementTest : AbstractElasticSearchTest("indexmngmnt", createIndex = false) {
     @Test
     fun `should list aliases`() {

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/SearchTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/SearchTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.contains
 import assertk.assertions.endsWith
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.elasticsearch.action.search.source
 import org.elasticsearch.common.unit.TimeValue
@@ -15,7 +14,6 @@ import org.elasticsearch.index.query.QueryBuilders.matchAllQuery
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.junit.jupiter.api.Test
 
-@InternalCoroutinesApi
 class SearchTest : AbstractElasticSearchTest(indexPrefix = "search") {
 
     @Test


### PR DESCRIPTION
As these do not seem to be required, and adding them means any use of index DAOs, etc., also requires the annotation.