### PR TITLE
beginnings of a search dsl based on MapBackedProperties

### DIFF
--- a/src/main/kotlin/io/inbot/eskotlinwrapper/IndexSettingsAndMappingsDSL.kt
+++ b/src/main/kotlin/io/inbot/eskotlinwrapper/IndexSettingsAndMappingsDSL.kt
@@ -19,9 +19,9 @@ fun String.snakeCaseToUnderscore(): String {
 }
 
 @DslMarker
-annotation class MapPropertiesDSL
+annotation class MapPropertiesDSLMarker
 
-@MapPropertiesDSL
+@MapPropertiesDSLMarker
 class IndexSettings : MapBackedProperties() {
     var replicas: Int by property("index.number_of_replicas")
     var shards: Int by property("index.number_of_shards")
@@ -57,7 +57,7 @@ class IndexSettings : MapBackedProperties() {
     }
 }
 
-@MapPropertiesDSL
+@MapPropertiesDSLMarker
 class FieldMapping(typeName: String) : MapBackedProperties() {
     var type: String by property()
     //    var properties: Map<String, FieldMapping>? by property()
@@ -77,7 +77,7 @@ class FieldMapping(typeName: String) : MapBackedProperties() {
     }
 }
 
-@MapPropertiesDSL
+@MapPropertiesDSLMarker
 class FieldMappings : MapBackedProperties() {
     fun text(name: String) = field(name, "text") {}
     fun text(name: String, block: FieldMapping.() -> Unit) = field(name, "text", block)
@@ -137,7 +137,7 @@ class FieldMappings : MapBackedProperties() {
     }
 }
 
-class IndexSettingsAndMappings private constructor(private val generateMetaFields: Boolean) {
+class IndexSettingsAndMappingsDSL private constructor(private val generateMetaFields: Boolean) {
     private var settings: IndexSettings? = null
     private var meta: MapBackedProperties? = null
     private var mappings: FieldMappings? = null
@@ -195,9 +195,9 @@ class IndexSettingsAndMappings private constructor(private val generateMetaField
         fun indexSettingsAndMappings(
             generateMetaFields: Boolean = true,
             pretty: Boolean = false,
-            block: IndexSettingsAndMappings.() -> Unit
+            block: IndexSettingsAndMappingsDSL.() -> Unit
         ): XContentBuilder {
-            val settingsAndMappings = IndexSettingsAndMappings(generateMetaFields)
+            val settingsAndMappings = IndexSettingsAndMappingsDSL(generateMetaFields)
             block.invoke(settingsAndMappings)
             return settingsAndMappings.build(pretty)
         }

--- a/src/main/kotlin/io/inbot/eskotlinwrapper/SearchDSL.kt
+++ b/src/main/kotlin/io/inbot/eskotlinwrapper/SearchDSL.kt
@@ -1,0 +1,78 @@
+@file:Suppress("unused")
+
+package io.inbot.eskotlinwrapper
+
+@DslMarker
+annotation class SearchDSLMarker
+
+open class ESQuery(val name: String, val queryDetails: MapBackedProperties = MapBackedProperties()) :
+    MutableMap<String, Any> by queryDetails {
+
+    fun toMap(): Map<String, MapBackedProperties> = mapOf(name to queryDetails)
+
+    // helpers to easily construct ESQuery instances of different types
+    // all ESQuery instances are mutable maps so you can tweak them
+    // for unsupported query types, you can use the custom method
+    companion object {
+        fun matchAll() = ESQuery("match_all")
+
+        @SearchDSLMarker
+        fun bool(block: BoolQuery.() -> Unit): ESQuery {
+            val bq = BoolQuery()
+            block.invoke(bq)
+            return bq
+        }
+
+        @SearchDSLMarker
+        fun term(field: String, value: String, block: (TermQuery.() -> Unit)? = null): ESQuery {
+            val tq = TermQuery(field, value)
+            block?.invoke(tq)
+            return tq
+        }
+
+        @SearchDSLMarker
+        fun match(field: String, value: String, block: TermQuery.() -> Unit): ESQuery {
+            val tq = TermQuery(field, value)
+            block.invoke(tq)
+            return tq
+        }
+
+        @SearchDSLMarker
+        fun custom(name: String, block: MapBackedProperties.() -> Unit): ESQuery {
+            val q = ESQuery(name)
+            block.invoke(q.queryDetails)
+            return q
+        }
+    }
+
+}
+
+class BoolQuery() : ESQuery(name = "bool") {
+    fun should(vararg q: ESQuery) = queryDetails.getOrCreateMutableList("should").addAll(q.map { it.toMap() })
+    fun must(vararg q: ESQuery) = queryDetails.getOrCreateMutableList("must").addAll(q.map { it.toMap() })
+    fun mustNot(vararg q: ESQuery) = queryDetails.getOrCreateMutableList("must_not").addAll(q.map { it.toMap() })
+    fun filter(vararg q: ESQuery) = queryDetails.getOrCreateMutableList("filter").addAll(q.map { it.toMap() })
+}
+
+class TermQuery(field: String, value: String) : ESQuery(name = "term") {
+    init {
+        this["field"] = field
+        this["value"] = value
+    }
+}
+
+class MatchQuery(field: String, value: String) : ESQuery(name = "match") {
+    init {
+        this["field"] = field
+        this["value"] = value
+    }
+}
+
+class SearchDSL() : MapBackedProperties() {
+    var from: Int by property()
+    var resultSize: Int by property("size") // clashes with Map.size
+
+    fun query(q: ESQuery) {
+        this["query"] = q.toMap()
+    }
+}

--- a/src/main/kotlin/org/elasticsearch/action/search/KotlinExtensions.kt
+++ b/src/main/kotlin/org/elasticsearch/action/search/KotlinExtensions.kt
@@ -1,5 +1,7 @@
 package org.elasticsearch.action.search
 
+import io.inbot.eskotlinwrapper.MapBackedProperties
+import io.inbot.eskotlinwrapper.SearchDSL
 import mu.KLogger
 import mu.KotlinLogging
 import org.elasticsearch.client.core.CountRequest
@@ -8,6 +10,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler
 import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.common.xcontent.stringify
 import org.elasticsearch.search.SearchModule
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import java.io.InputStream
@@ -69,6 +72,12 @@ fun SearchRequest.source(reader: Reader, deprecationHandler: DeprecationHandler 
     ).use {
         source(SearchSourceBuilder.fromXContent(it))
     }
+}
+
+fun SearchRequest.dsl(pretty: Boolean=false,block: SearchDSL.()->Unit) {
+    val searchDSL = SearchDSL()
+    block.invoke(searchDSL)
+    source(searchDSL.stringify(pretty))
 }
 
 /**

--- a/src/main/kotlin/org/elasticsearch/client/KotlinExtensions.kt
+++ b/src/main/kotlin/org/elasticsearch/client/KotlinExtensions.kt
@@ -2,7 +2,7 @@ package org.elasticsearch.client
 
 import io.inbot.eskotlinwrapper.AsyncIndexRepository
 import io.inbot.eskotlinwrapper.IndexRepository
-import io.inbot.eskotlinwrapper.IndexSettingsAndMappings
+import io.inbot.eskotlinwrapper.IndexSettingsAndMappingsDSL
 import io.inbot.eskotlinwrapper.JacksonModelReaderAndWriter
 import io.inbot.eskotlinwrapper.ModelReaderAndWriter
 import io.inbot.eskotlinwrapper.SuspendingActionListener.Companion.suspending
@@ -247,6 +247,6 @@ fun CreateIndexRequest.source(json:String): CreateIndexRequest = source(json,XCo
 
 fun CreateIndexRequest.configure(generateMetaFields: Boolean = true,
                                  pretty: Boolean = false,
-                                 block: IndexSettingsAndMappings.() -> Unit) {
-    source(IndexSettingsAndMappings.indexSettingsAndMappings(generateMetaFields = generateMetaFields, pretty = pretty, block = block))
+                                 block: IndexSettingsAndMappingsDSL.() -> Unit) {
+    source(IndexSettingsAndMappingsDSL.indexSettingsAndMappings(generateMetaFields = generateMetaFields, pretty = pretty, block = block))
 }

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/IndexSettingsAndMappingsKtTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/IndexSettingsAndMappingsKtTest.kt
@@ -2,7 +2,7 @@ package io.inbot.eskotlinwrapper
 
 import assertk.assertThat
 import assertk.assertions.contains
-import io.inbot.eskotlinwrapper.IndexSettingsAndMappings.Companion.indexSettingsAndMappings
+import io.inbot.eskotlinwrapper.IndexSettingsAndMappingsDSL.Companion.indexSettingsAndMappings
 import org.elasticsearch.common.xcontent.stringify
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/io/inbot/eskotlinwrapper/SearchDSLTest.kt
+++ b/src/test/kotlin/io/inbot/eskotlinwrapper/SearchDSLTest.kt
@@ -1,0 +1,47 @@
+package io.inbot.eskotlinwrapper
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import io.inbot.eskotlinwrapper.ESQuery.Companion.bool
+import io.inbot.eskotlinwrapper.ESQuery.Companion.match
+import io.inbot.eskotlinwrapper.ESQuery.Companion.term
+import org.elasticsearch.common.xcontent.stringify
+import org.junit.jupiter.api.Test
+
+class SearchDSLTest {
+    @Test
+    fun `should construct matchAll query`() {
+        val s = SearchDSL()
+        s.apply {
+            resultSize=10
+            from=0
+            query(ESQuery.matchAll())
+        }
+        println(s.stringify(true))
+
+        assertThat(s["from"]).isEqualTo(0)
+        assertThat(s["query"] as Map<String,Any>).hasSize(1)
+        assertThat((s["query"] as Map<String,Any>).keys).contains("match_all")
+    }
+
+    @Test
+    fun `should construct bool`() {
+        val s = SearchDSL()
+        s.apply {
+
+            query(bool {
+                should(
+                    term("title", "foo"),
+                    match("title","quick brown fox") {
+                        // ESQuery is a MutableMap that modifies the underlying queryDetails
+                        this["value"] = "bar"
+                    }
+                )
+            })
+        }
+        println(s.stringify(true))
+        assertThat(s.stringify()).contains("bar")
+    }
+}


### PR DESCRIPTION
Builds on `MapBackedProperties` that I added for the mapping dsl. Turns out that this is a nice way to deal with ES having lots of weird corners.

Very much early stage but already showing promise.